### PR TITLE
Prefer named export instead of default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ If all of these questions can be answered with a strong 'YES', go ahead with a p
     - What will the impact be on existing projects.
     - How can the changes be (temporarily) ignored. Add a code snippet.
 
+☝️ For an example PR, see #1.
+
 When the PR is ready for review, request reviews from the rest of the team. Discussion should happen in the PR comments as much as possible to ensure future developers can see why certain decissions were made in the past.
 
 When more than half of the rest of the team agrees with the proposed changes, the PR can be merged. 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-toc",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ESLint config for ToC TypeScript based projects",
   "repository": "https://github.com/tired-of-cancer/eslint-config-toc",
   "main": "index.js",

--- a/typescript.js
+++ b/typescript.js
@@ -41,6 +41,10 @@ module.exports = {
             singleQuote: true,
           },
         ],
+
+        // Enforce named exports to ensure consistent usage of component throughout the codebase.
+        'import/prefer-default-export': 'off',
+        'import/no-default-export': 'error',
       },
     },
   ],


### PR DESCRIPTION
![Thank you for reviewing](https://media.giphy.com/media/I7svnJrMmd2CFOLK8F/giphy.gif)

## Reason for this change

Our default config (airbnb) uses `import/prefer-default-export` to enforce a default (versus named) export when only one thing is exported from a module. I propose we invert this requirement and prefer (or require) named exports from all modules, regardless of how many exports they have.

The biggest advantage in my opinion is that we guarantee consistent component naming throughout the codebase, and allow our linters to warn us if we make a mistake. 

For a detailed bog on the benefits of inverting this rule, see: https://humanwhocodes.com/blog/2019/01/stop-using-default-exports-javascript-module/

## Impact of this change on existing projects

Since this configuration is only going to be used in future project, there is no impact yet.

If we would decide to add the config to the old Untire app project, we could add this snippet to its eslint config to (temporarily) ignore the proposed change:

``` js
// Allow default export with a warning until they have been refactored out of the codebase.
'import/no-default-export': 'warning',
```
