### PR TITLE
Add prettier rc config to published files index

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "typescript.js",
     "react.js",
     "react-native.js",
-    "tsconfig.json"
+    "tsconfig.json",
+    ".prettierrc.js"
   ],
   "devDependencies": {
     "eslint": "8.20.0"


### PR DESCRIPTION
Fixes a missing file in the published NPM package. The prettier config file is used directly by our ESLint setup and needs to be included.