### PR TITLE
Add documentation for including prettier config

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,9 @@ module.exports = {
 };
 ```
 
-3. If you use TypeScript, add `"extends": "eslint-config-toc/tsconfig.json"` to your `tsconfig.json`.
-4. Happy linting!
+3. Add `"extends": "eslint-config-toc/tsconfig.json"` to your `tsconfig.json`.
+4. Add `"prettier": "eslint-config-toc/.prettierrc"` to your `package.json`.
+5. Happy linting!
 
 ## 📣 Proposing changes
 


### PR DESCRIPTION
Consumers of this library can ensure they use the same prettier configuration that we use in the ESLint ruleset by including it via their package json. This allows our library to remain the consistent source of truth when we update our prettier config.