### PR TITLE
Add separate typescript templates for extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,17 @@ This package allows us to make decisions on code styling for all TypeScript base
 
 - [Usage](#-usage)
 - [Proposing changes](#-proposing-changes)
-- [Versioning](#-versioning)
+- [Versioning and releasing](#-versioning-and-releasing)
 - [Acknowledgements](#-acknowledgements)
 
 ## ⚙️ Usage
 
-1. `yarn add -D eslint eslint-config-toc`
-2. Setup your project config in `.eslintrc.js`:
+1. `yarn add -D eslint eslint-config-toc`.
+2. Add `"prettier": "eslint-config-toc/.prettierrc"` to your `package.json`.
 
 **For bare TypeScript projects**
+
+3. Setup your project config in `.eslintrc.js`:
 
 ```js
 // This enables ESLint to use dependencies of this config
@@ -30,7 +32,11 @@ module.exports = {
 };
 ```
 
+4. Add `"extends": "eslint-config-toc/tsconfig-typescript.json"` to your `tsconfig.json`.
+
 **For React web projects**
+
+3. Setup your project config in `.eslintrc.js`:
 
 ```js
 // This enables ESLint to use dependencies of this config
@@ -42,7 +48,11 @@ module.exports = {
 };
 ```
 
+4. Add `"extends": "eslint-config-toc/tsconfig-react.json"` to your `tsconfig.json`.
+
 **For React Native projects**
+
+3. Setup your project config in `.eslintrc.js`:
 
 ```js
 // This enables ESLint to use dependencies of this config
@@ -54,9 +64,9 @@ module.exports = {
 };
 ```
 
-3. Add `"extends": "eslint-config-toc/tsconfig.json"` to your `tsconfig.json`.
-4. Add `"prettier": "eslint-config-toc/.prettierrc"` to your `package.json`.
-5. Happy linting!
+4. Add `"extends": "eslint-config-toc/tsconfig-react-native.json"` to your `tsconfig.json`.
+
+5. Happy linting! 🎉
 
 ## 📣 Proposing changes
 
@@ -72,12 +82,18 @@ If all of these questions can be answered with a strong 'YES', go ahead with a p
 1. Create a PR to this repository containing:
    - The change, added to the appropriate config (for example, React Native specific deviation rules should be added to `react-native.js`).
    - A comment right above the change(s) in the config files that explains in short why we are using that deviation.
-   - An update to the version number in `package.json`. See [versioning](#-versioning) for details.
-   - If applicable; the changes required to keep the files in this repository valid (test with `yarn lint`).
+   - If applicable; the changes required to keep the files in this repository valid (test with `yarn lint` and `yarn prettier`).
 1. In the PR body, describe the following:
    - What is the reason for this change.
    - What will the impact be on existing projects.
    - How can the changes be (temporarily) ignored. Add a code snippet.
+1. Add an appropriate label to the PR. These are used in our changelog automation:
+
+- `bug` for solving bugs in this library or it's ci configuration.
+- `documentation` for updating the instructions in the README or clarifying comments with existing deviations.
+- `dependencies` for updating existing dependencies. These are usually done automatically by Renovate.
+- `feature` for proposing a new rule deviation or adding a new dependency.
+- `breaking` for any of the above changes when it also will cause breaking changes in any project depending on this library.
 
 ☝️ For an example PR, see #1.
 
@@ -85,11 +101,17 @@ When the PR is ready for review, request reviews from the rest of the team. Disc
 
 When more than half of the rest of the team agrees with the proposed changes, the PR can be merged.
 
-## 📒 Versioning
+## 🚀 Versioning and releasing
 
-- Patch releases are for improved documentation, fixing a rule to stop reporting false positives and internal code changes.
-- Minor releases are for changes to rules that can automatically be fixed.
-- Major releases happen when rules are changed that can't be fixed automatically.
+When a PR is merged, the release notes for the next draft release are automatically prepared. Based on the added labels, the version number in the release title and package.json may be automatically updated as well.
+
+When we are ready to publish a new version to NPM, all we need to do is publish the draft release:
+
+1. Go to the [releases overview](https://github.com/tired-of-cancer/eslint-config-toc/releases).
+1. Check if the last change has been added (the Github action workflow needs to complete after merging the most recent PR).
+1. Edit the existing draft release. If there is no draft release, there were no changes since the last release.
+1. Press `Publish release`.
+1. Presto! A new Github release and tag have been made. A workflow will automatically publish this version to NPM.
 
 ## 🦸 Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "repository": "https://github.com/tired-of-cancer/eslint-config-toc",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "prettier": "prettier --write ."
   },
   "keywords": [
     "eslint",
@@ -18,7 +19,9 @@
     "typescript.js",
     "react.js",
     "react-native.js",
-    "tsconfig.json",
+    "tsconfig-typescript.json",
+    "tsconfig-react.json",
+    "tsconfig-react-native.json",
     ".prettierrc.js"
   ],
   "devDependencies": {
@@ -30,6 +33,9 @@
   "dependencies": {
     "@react-native-community/eslint-config": "^3.0.3",
     "@rushstack/eslint-patch": "^1.1.4",
+    "@tsconfig/create-react-app": "^1.0.2",
+    "@tsconfig/react-native": "^2.0.2",
+    "@tsconfig/recommended": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^5.30.6",
     "@typescript-eslint/parser": "^5.30.6",
     "eslint-config-airbnb": "^19.0.4",

--- a/tsconfig-react-native.json
+++ b/tsconfig-react-native.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/react-native/tsconfig.json"
+}

--- a/tsconfig-react.json
+++ b/tsconfig-react.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/create-react-app/tsconfig.json"
+}

--- a/tsconfig-typescript.json
+++ b/tsconfig-typescript.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,3 @@
 {
-  "compilerOptions": {
-    "strict": true,
-    "forceConsistentCasingInFileNames": true
-  }
+  "extends": "./tsconfig-typescript.json"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -326,6 +326,21 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.1.4.tgz#0c8b74c50f29ee44f423f7416829c0bf8bb5eb27"
   integrity sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==
 
+"@tsconfig/create-react-app@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/create-react-app/-/create-react-app-1.0.2.tgz#e05e2d209b98e21665ed4097fe2d37f638447b0e"
+  integrity sha512-Vg+pErSM6hTcSzxPqNwFg0dk+y0R1Obp8uLV1MDdfd7j98FyOFqtqkdxb9wqIx9vtDW5GCH7zg6DyoHJzMT12g==
+
+"@tsconfig/react-native@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/react-native/-/react-native-2.0.2.tgz#ac9b8ceb1de91e2f23ab89f915490a1a4afd65a0"
+  integrity sha512-OY+qydDk8Xw+VONvAFB6WTZAi3OP/KSQWNIeuJgkGFHGV3epw8qlctJQ35+fKGG4919nGbNS9ZI0JuZl1y8w2g==
+
+"@tsconfig/recommended@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@tsconfig/recommended/-/recommended-1.0.1.tgz#7619bad397e06ead1c5182926c944e0ca6177f52"
+  integrity sha512-2xN+iGTbPBEzGSnVp/Hd64vKJCJWxsi9gfs88x4PPMyEjHJoA3o5BY9r5OLPHIZU2pAQxkSAsJFqn6itClP8mQ==
+
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"


### PR DESCRIPTION
## Reason for this change

To further unify our linting we should also use the same TypeScript configuration where applicable. Using community recommendations will help prevent hard-to-debug typescript issues. See also: https://www.bayanbennett.com/posts/stop-messing-with-tsconfig/

Because TypeScript setup differs for vanilla TS, React and React Native projects, this configuration will need to offer one for each type of project.

## Impact of this change on existing projects

Since this library is not in use in any real projects yet, there is no impact. These changes impact the installation steps and the README has been updated accordingly.