### PR TITLE
Add workflow to enforce pr labels

### DIFF
--- a/.github/workflows/enforce-pr-labels.yml
+++ b/.github/workflows/enforce-pr-labels.yml
@@ -1,0 +1,13 @@
+name: Enforce Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v2
+        with:
+          mode: minimum
+          count: 1
+          labels: 'bug, documentation, dependencies, feature'


### PR DESCRIPTION
Adds a workflow that will fail while the PR does not have at least one of the listed labels:

- bug
- documentation
- dependencies
- feature

This will help us ensure that the changelog in our release notes is correctly structured and the next semver version is correctly deduced from changes in recent PRs.