### PR TITLE
Add rules for sorting and placing imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.7.1",
     "typescript": "^4.7.4"
   }

--- a/typescript.js
+++ b/typescript.js
@@ -12,6 +12,17 @@ const rules = {
   // Enforce named exports to ensure consistent usage of component throughout the codebase.
   'import/prefer-default-export': 'off',
   'import/no-default-export': 'error',
+
+  // All of these import rules are auto-fixable, keeping our files more consistent and readable
+  // Sort all imports and exports in a default alphabetic order
+  'simple-import-sort/imports': 'error',
+  'simple-import-sort/exports': 'error',
+  // Enforce imports at the top of the file
+  'import/first': 'error',
+  // Enforce a newline after the import section
+  'import/newline-after-import': 'error',
+  // Guard against duplicate imports
+  'import/no-duplicates': 'error',
 };
 
 module.exports = {
@@ -19,7 +30,7 @@ module.exports = {
 
   root: true,
 
-  plugins: ['prettier'],
+  plugins: ['simple-import-sort', 'import', 'prettier'],
 
   extends: ['airbnb', 'prettier'],
 
@@ -45,7 +56,12 @@ module.exports = {
         project: './tsconfig.json',
       },
 
-      plugins: ['@typescript-eslint', 'prettier'],
+      plugins: [
+        '@typescript-eslint',
+        'simple-import-sort',
+        'import',
+        'prettier',
+      ],
 
       extends: [
         'airbnb',

--- a/yarn.lock
+++ b/yarn.lock
@@ -944,6 +944,11 @@ eslint-plugin-react@^7.26.1, eslint-plugin-react@^7.30.1:
     semver "^6.3.0"
     string.prototype.matchall "^4.0.7"
 
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
## Reason for this change

I propose to keep our imports sorted alphabetically, at the top of the file, with a newline to separate blocks of imports from the rest of our code. This will make it easier to read the import section and file as a whole.

To have to do so manually might not be considered worth the effort, which is why I chose [eslint-plugin-import-sort](https://github.com/lydell/eslint-plugin-simple-import-sort) specifically: all of the configured rules can be auto-fixed by ESLint and Prettier. As long as we all use the same config (the whole idea of this project) it should be pretty seamless.

## Impact of this change on existing projects

None, the package has not been applied to any project yet. Applying it to existing code bases will probably cause a lot of linting errors about imports, but those should be auto-fixable (`eslint . --fix`).