### PR TITLE
Propose sorting react native styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,12 @@
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-native": "4.0.0",
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "prettier": "^2.7.1",
     "typescript": "^4.7.4"
+  },
+  "resolutions": {
+    "eslint-plugin-react-native": "4.0.0"
   }
 }

--- a/react-native.js
+++ b/react-native.js
@@ -23,5 +23,12 @@ module.exports = {
   ],
 
   // Add React Native specific rule deviations here.
-  rules: {},
+  rules: {
+    // Sort RN styles, this will sort typed stylenames and style props in alphabetic order
+    'react-native/sort-styles': [
+      'error',
+      'asc',
+      { ignoreClassNames: false, ignoreStyleProperties: false },
+    ],
+  },
 };

--- a/react.js
+++ b/react.js
@@ -1,7 +1,7 @@
 module.exports = {
   root: true,
 
-  plugins: [],
+  plugins: ['react'],
 
   settings: {
     react: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,10 +916,10 @@ eslint-plugin-react-native-globals@^0.1.1:
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-native-globals/-/eslint-plugin-react-native-globals-0.1.2.tgz#ee1348bc2ceb912303ce6bdbd22e2f045ea86ea2"
   integrity sha512-9aEPf1JEpiTjcFAmmyw8eiIXmcNZOqaZyHO77wgm0/dWfT/oxC1SrIq8ET38pMxHYrcB6Uew+TzUVsBeczF88g==
 
-eslint-plugin-react-native@^3.11.0:
-  version "3.11.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-3.11.0.tgz#c73b0886abb397867e5e6689d3a6a418682e6bac"
-  integrity sha512-7F3OTwrtQPfPFd+VygqKA2VZ0f2fz0M4gJmry/TRE18JBb94/OtMxwbL7Oqwu7FGyrdeIOWnXQbBAveMcSTZIA==
+eslint-plugin-react-native@4.0.0, eslint-plugin-react-native@^3.11.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-native/-/eslint-plugin-react-native-4.0.0.tgz#eec41984abe4970bdd7c6082dff7a98a5e34d0bb"
+  integrity sha512-kMmdxrSY7A1WgdqaGC+rY/28rh7kBGNBRsk48ovqkQmdg5j4K+DaFmegENDzMrdLkoufKGRNkKX6bgSwQTCAxQ==
   dependencies:
     "@babel/traverse" "^7.7.4"
     eslint-plugin-react-native-globals "^0.1.1"


### PR DESCRIPTION
## Reason for this change

Sorting the style properties in our style objects will make them more readable. Enforcing this manually might not be worth the trade-off but with this rule we can have our editor automatically fix the order for us.

## Impact of this change on existing projects

None, the package has not been applied to any project yet. Applying it to existing code bases will probably cause a lot of linting errors about styling order, but those should be auto-fixable (`eslint . --fix`).

## Note

This PR also pins the dependency for `eslint-plugin-react-native` to v4 as a yarn package resolution. This is because otherwise `@react-native-community/eslint-config` explicitly installs version 3.x which is incompatible with eslint v8. See also: https://github.com/facebook/react-native/pull/31334