### PR TITLE
Add react jsx sort props rule

### DIFF
--- a/react.js
+++ b/react.js
@@ -21,5 +21,14 @@ module.exports = {
   ],
 
   // Add React project specific rule deviations here.
-  rules: {},
+  rules: {
+    // Sort props for JSX component alphabetically (while keeping callbacks at the end) to improve readability
+    'react/jsx-sort-props': [
+      'error',
+      {
+        callbacksLast: true,
+        ignoreCase: true,
+      },
+    ],
+  },
 };


### PR DESCRIPTION
## Reason for this change

I propose to keep our JSX props sorted alphabetically, with all callbacks sorted separately at the end. This will make it easier to read components and compare them.

To have to do so manually might not be considered worth the effort, but this rule can be auto-fixed by ESLint. As long as we all use the same config (the whole idea of this project) it should be pretty seamless.

## Impact of this change on existing projects

None, the package has not been applied to any project yet. Applying it to existing code bases will probably cause a lot of linting errors about JSX property order, but those should be auto-fixable (`eslint . --fix`).