### PR TITLE
Set max line length to 120 ignoring long strings

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -23,6 +23,19 @@ const rules = {
   'import/newline-after-import': 'error',
   // Guard against duplicate imports
   'import/no-duplicates': 'error',
+
+  // Sets the maximum line length at 120 (instead of the default 80).
+  // Modern day screens are large enough to make this comfortable
+  'max-len': [
+    'error',
+    {
+      code: 120,
+      // Ignores URLs and Quoted strings because breaking them for readability can cause issues
+      ignoreUrls: true,
+      ignoreStrings: true,
+      ignoreTemplateLiterals: true,
+    },
+  ],
 };
 
 module.exports = {


### PR DESCRIPTION
## Reason for this change

Traditionally, the maximum line length of code files has been 80 characters. However, with modern screens this is conservative. Even when comparing code side by side a line length of 100 or even 120 is often recommended. This proposal suggests to use 120.

## Impact of this change on existing projects

None, the package has not been applied to any project yet. Applying it to existing code bases will probably cause a lot of linting errors about line wrapping, but those should be auto-fixable (eslint . --fix).

## Note on Prettier

Changing the line length for ESLint will increase the chances of conflicting with Prettier's `print-width` rule, which also defaults to 80. This is often resolved by matching these rules (setting `print-width: 120` in this case). However, Prettier discourages this convention:

> For readability we recommend against using more than 80 characters:
>
> In code styleguides, maximum line length rules are often set to 100 or 120. However, when humans write code, they don’t strive to reach the maximum number of columns on every line. Developers often use whitespace to break up long lines for readability. In practice, the average line length often ends up well below the maximum.
>
> Prettier’s printWidth option does not work the same way. It is not the hard upper allowed line length limit. It is a way to say to Prettier roughly how long you’d like lines to be. Prettier will make both shorter and longer lines, but generally strive to meet the specified printWidth.
>
> Remember, computers are dumb. You need to explicitly tell them what to do, while humans can make their own (implicit) judgements, for example on when to break a line.
>
> In other words, don’t try to use printWidth as if it was ESLint’s [max-len](https://eslint.org/docs/rules/max-len) – they’re not the same. max-len just says what the maximum allowed line length is, but not what the generally preferred length is – which is what printWidth specifies.

(Source: [Prettier documentation](https://prettier.io/docs/en/options.html#print-width))

On first experimentation I don't see formatting issues popping up yet, but if they do (usually causing ESLint to toggle the wrapping off a line of code back and forth on auto-format) we should reconsider this option.