### PR TITLE
Disallow unused vars

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -36,6 +36,9 @@ const rules = {
       ignoreTemplateLiterals: true,
     },
   ],
+
+  // Disallowing unused vars will help us clean up redundant properties and definitions
+  '@typescript-eslint/no-unused-vars': 'error',
 };
 
 module.exports = {


### PR DESCRIPTION
## Reason for this change

Disallowing unused vars will help us clean up redundant properties and definitions.

## Impact of this change on existing projects

None