### PR TITLE
Disallow any as a type definition

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -39,6 +39,10 @@ const rules = {
 
   // Disallowing unused vars will help us clean up redundant properties and definitions
   '@typescript-eslint/no-unused-vars': 'error',
+
+  // Disallowing the 'any' type will help us increase TypeSafety from the get-go. Use 'unknown' instead if necessary
+  // See also https://dev.to/arikaturika/typescript-why-to-use-unknown-instead-of-any-41i8
+  '@typescript-eslint/no-explicit-any': 'error',
 };
 
 module.exports = {


### PR DESCRIPTION
## Reason for this change

Disallowing the `any` type will help us increase TypeSafety from the get-go. Use `unknown` instead if necessary. See also https://dev.to/arikaturika/typescript-why-to-use-unknown-instead-of-any-41i8

## Impact of this change on existing projects

Applying the package to existing code bases will probably cause a lot of linting errors about using the `any` type. These can be hard to fix because `any` is usually used as a last resort when applying a strong type is hard. As a halfway solution, replace all occurrences of `any` by `unknown`.

To downscale this error to a warning instead and solve those warnings gradually over time, add the following to your local `.eslintrc.json`:

```js
// Override no-explicit-any to give a warning instead of an error. 
// This gives us time to gradually refactor the type definitions.
'@typescript-eslint/no-explicit-any': 'warning',
```