### PR TITLE
Refactor typescript plugin extension definition

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -45,14 +45,29 @@ const rules = {
   '@typescript-eslint/no-explicit-any': 'error',
 };
 
+// Add plugins that should be used in both vanilla JS and TS linting
+const jsOnlyPlugins = ['simple-import-sort', 'import', 'prettier'];
+
+// Add plugins that should only be used in TS linting
+const tsSpecificPlugins = ['@typescript-eslint'];
+
+// Add extensions that should be used in both vanilla JS and TS linting
+const jsOnlyExtensions = ['airbnb', 'prettier'];
+
+// Add extensions that should only be used in TS linting
+const tsSpecificExtensions = [
+  'airbnb-typescript',
+  'plugin:@typescript-eslint/recommended',
+];
+
 module.exports = {
   parser: '@typescript-eslint/parser',
 
   root: true,
 
-  plugins: ['simple-import-sort', 'import', 'prettier'],
+  plugins: jsOnlyPlugins,
 
-  extends: ['airbnb', 'prettier'],
+  extends: jsOnlyExtensions,
 
   settings: {
     'import/resolver': 'node',
@@ -76,19 +91,9 @@ module.exports = {
         project: './tsconfig.json',
       },
 
-      plugins: [
-        '@typescript-eslint',
-        'simple-import-sort',
-        'import',
-        'prettier',
-      ],
+      plugins: [...jsOnlyPlugins, ...tsSpecificPlugins],
 
-      extends: [
-        'airbnb',
-        'airbnb-typescript',
-        'plugin:@typescript-eslint/recommended',
-        'prettier',
-      ],
+      extends: [...jsOnlyExtensions, ...tsSpecificExtensions],
 
       rules,
     },


### PR DESCRIPTION
To allow this configuration to apply to vanilla JS files as well (for example, these eslint configuration files themselves) we need to define a plugin and extension array for both general use, and for typescript specific rules (using the override option). I set this up with separate configuration using a shared `rules` object to prevent inconsistencies. However, updating the plugins and extensions still requires the developer to pay attention to not introduce inconsistencies between these configurations.

This PR adds separate config arrays for generic extensions/plugins and typescript-specific ones. These are then combined for the typescript override configuration. This means the developer now only needs to choose in which array to add the new plugin/extension, instead of making sure to add it to both in some cases.