### PR TITLE
Add resolution note to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ This package allows us to make decisions on code styling for all TypeScript base
 This library requires node 16+. 
 
 1. `yarn add -D eslint eslint-config-toc`.
-2. Add `"prettier": "eslint-config-toc/.prettierrc"` to your `package.json`.
+2. Add the following to your `package.json`:
+
+```json
+"prettier": "eslint-config-toc/.prettierrc",
+"resolutions": {
+  "eslint-plugin-react-native": "4.0.0"
+}
+```
 
 **For bare TypeScript projects**
 


### PR DESCRIPTION
Apparently the resolution in package json for a known issue in the `eslint-plugin-react-native` dependency is not always passed on correctly to the project where this library is installed. The workaround seems to be to add the resolution to the project `package.json` as well. This is unfortunate, since it adds an extra instruction to the setup and will require a breaking change in the future when we no longer need the resolution, but the alternative is to downgrade the eslint dependency to v7 and that would also add complexity to the setup.
