### PR TITLE
Disallow use of semicolon

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,4 +6,4 @@ module.exports = Object.assign(
       node: true,
     },
   }
-);
+)

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
   singleQuote: true,
-};
+  semi: false,
+}

--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ This library requires node 16+.
 ```js
 // This enables ESLint to use dependencies of this config
 // (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins');
+require('eslint-config-toc/setup-plugins')
 
 module.exports = {
   extends: ['toc/typescript'],
-};
+}
 ```
 
 4. Add `"extends": "eslint-config-toc/tsconfig-typescript.json"` to your `tsconfig.json`.
@@ -50,11 +50,11 @@ module.exports = {
 ```js
 // This enables ESLint to use dependencies of this config
 // (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins');
+require('eslint-config-toc/setup-plugins')
 
 module.exports = {
   extends: ['toc/react'],
-};
+}
 ```
 
 4. Add `"extends": "eslint-config-toc/tsconfig-react.json"` to your `tsconfig.json`.
@@ -66,11 +66,11 @@ module.exports = {
 ```js
 // This enables ESLint to use dependencies of this config
 // (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins');
+require('eslint-config-toc/setup-plugins')
 
 module.exports = {
   extends: ['toc/nexstjs'],
-};
+}
 ```
 
 4. Add `"extends": "eslint-config-toc/tsconfig-react.json"` to your `tsconfig.json`.
@@ -82,11 +82,11 @@ module.exports = {
 ```js
 // This enables ESLint to use dependencies of this config
 // (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins');
+require('eslint-config-toc/setup-plugins')
 
 module.exports = {
   extends: ['toc/react-native'],
-};
+}
 ```
 
 4. Add `"extends": "eslint-config-toc/tsconfig-react-native.json"` to your `tsconfig.json`.

--- a/nextjs.js
+++ b/nextjs.js
@@ -11,4 +11,4 @@ module.exports = {
 
   // Add NextJS project specific rule deviations here.
   rules: {},
-};
+}

--- a/react-native.js
+++ b/react-native.js
@@ -18,4 +18,4 @@ module.exports = {
       { ignoreClassNames: false, ignoreStyleProperties: false },
     ],
   },
-};
+}

--- a/react.js
+++ b/react.js
@@ -39,4 +39,4 @@ module.exports = {
     'unicorn/prefer-query-selector': 'off',
     'unicorn/prevent-abbreviations': 'off',
   },
-};
+}

--- a/setup-plugins.js
+++ b/setup-plugins.js
@@ -1,3 +1,3 @@
 // This enables ESLint to use dependencies of this config
 // (see https://github.com/eslint/eslint/issues/3458)
-require('@rushstack/eslint-patch/modern-module-resolution');
+require('@rushstack/eslint-patch/modern-module-resolution')

--- a/typescript.js
+++ b/typescript.js
@@ -9,6 +9,9 @@ const rules = {
     },
   ],
 
+  // Omitting semicolons makes the codebase easier to read and to manipulate (shifting lines)
+  semi: ['error', 'never'],
+
   // Enforce named exports to ensure consistent usage of component throughout the codebase.
   'import/prefer-default-export': 'off',
   'import/no-default-export': 'error',
@@ -43,23 +46,23 @@ const rules = {
   // Disallowing the 'any' type will help us increase TypeSafety from the get-go. Use 'unknown' instead if necessary
   // See also https://dev.to/arikaturika/typescript-why-to-use-unknown-instead-of-any-41i8
   '@typescript-eslint/no-explicit-any': 'error',
-};
+}
 
 // Add plugins that should be used in both vanilla JS and TS linting
-const jsOnlyPlugins = ['simple-import-sort', 'import', 'unicorn'];
+const jsOnlyPlugins = ['simple-import-sort', 'import', 'unicorn']
 
 // Add plugins that should only be used in TS linting
-const tsSpecificPlugins = ['@typescript-eslint'];
+const tsSpecificPlugins = ['@typescript-eslint']
 
 // Add extensions that should be used in both vanilla JS and TS linting
-const jsOnlyExtensions = ['airbnb'];
+const jsOnlyExtensions = ['airbnb']
 
 // Add extensions that should only be used in TS linting
 const tsSpecificExtensions = [
   'airbnb-typescript',
   'plugin:unicorn/recommended',
   'plugin:@typescript-eslint/recommended',
-];
+]
 
 module.exports = {
   parser: '@typescript-eslint/parser',
@@ -105,4 +108,4 @@ module.exports = {
     browser: true,
     jest: true,
   },
-};
+}


### PR DESCRIPTION
![Thank you for reviewing](https://media.giphy.com/media/Qxjy1SjXqFD4jnmyub/giphy.gif)

## Reason for this change

By default, the airbnb config [enforces semicolons](https://github.com/airbnb/javascript#semicolons). Their reason for doing so is that when concatenated incorrectly, JavaScript files *could* be executed erroneously. This is such an edge-case however that many debates are held for and against the practice with the general consensus being that it doesn't really matter.

Usually I would be a proponent of sticking with the convention in such a case, but in this case I see a big advantage in omitting semicolons in our projects. When moving around lines of code (alt + up/down in VSCode), semicolons can get stuck in the wrong places. This usually leads to broken code. Easily fixable, but when it happens a lot it can slow you down.

In my opinion, the code becomes more readable and more easy to work with if we ban semicolons, which is why I propose this rules change.

## Impact of this change on existing projects

This issue is auto-fixable. Linting will break on existing projects but using `yarn lint --fix && yarn prettier --write .` in the project directory should fix all problems. 