### PR TITLE
Disable conflicting unicorn loop rule

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -46,6 +46,10 @@ const rules = {
   // Disallowing the 'any' type will help us increase TypeSafety from the get-go. Use 'unknown' instead if necessary
   // See also https://dev.to/arikaturika/typescript-why-to-use-unknown-instead-of-any-41i8
   '@typescript-eslint/no-explicit-any': 'error',
+
+  // The unicorn rule to disallow array.forEach() conflicts directly with the airbnb rule to disallow loops
+  // In this case, we choose to follow the airbnb guidelines. See also https://github.com/airbnb/javascript/issues/1271
+  'unicorn/no-array-for-each': 'off',
 }
 
 // Add plugins that should be used in both vanilla JS and TS linting


### PR DESCRIPTION
![Thank you for reviewing](https://media.giphy.com/media/K2WZXsw7yYiP3bp7GU/giphy-downsized.gif)

## Reason for this change

We currently have conflicting rules when it comes to iterating over arrays programmatically. airbnb wants us to stay away from loops and use `forEach` and `map`. unicorn wants us to always use loops and refactor `forEach` into `for X in Y`. This means there currently is no valid way to iterate over arrays :sweat_smile:

After reading through a lengthy discussion on this, I think it is best to go with airbnb's side and disable the unicorn rule. Mainly because I think the actual details don't matter that much, but the airbnb guide is used often when working with React and React Native while the unicorn rules are less known and applied. By following airbnb we increase the chance that new developers on the project will have an easy time contributing.

## Impact of this change on existing projects

Since we didn't encounter this issue before, there should be no impact since there was no valid way to apply either way of working.