### PR TITLE
Fix linting workflow false negative

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           eslint: true
           prettier: true
+          continue_on_error: false


### PR DESCRIPTION
![You should have specified](https://media.giphy.com/media/7uWPL89EubOBvjwY54/giphy-downsized.gif)

Apparently, without specifying, the linting action assumes that it should pass if any or all of the linters fail. 🤷 This PR specifies that we want the action to fail if any linter fails during the check 🤦 