### PR TITLE
moved filename case to typescript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.DS_Store
+.vscode

--- a/react.js
+++ b/react.js
@@ -33,7 +33,6 @@ module.exports = {
 
     // Some unicorn rules are not compatible with React, so we disable them for those projects
     // See also https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
-    'unicorn/filename-case': 'off',
     'unicorn/no-null': 'off',
     'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-query-selector': 'off',

--- a/typescript.js
+++ b/typescript.js
@@ -50,6 +50,9 @@ const rules = {
   // The unicorn rule to disallow array.forEach() conflicts directly with the airbnb rule to disallow loops
   // In this case, we choose to follow the airbnb guidelines. See also https://github.com/airbnb/javascript/issues/1271
   'unicorn/no-array-for-each': 'off',
+
+  // This goes against the principle set by one of the most popular linting packages. See also https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
+  'unicorn/filename-case': 'off',
 }
 
 // Add plugins that should be used in both vanilla JS and TS linting


### PR DESCRIPTION
![Thank you for reviewing](https://media.giphy.com/media/2iyqDbgJszmO4/giphy-downsized.gif)

## Reason for this change
Moved [filename-case](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/filename-case.md) exception rule to typescript. So Typescript projects can also enjoy non-kebab-style-file-names 

## Impact of this change on existing projects
None, Typescript projects will now benefit from this rule as well.
