### PR TITLE
reverted filename case

### DIFF
--- a/react.js
+++ b/react.js
@@ -33,6 +33,7 @@ module.exports = {
 
     // Some unicorn rules are not compatible with React, so we disable them for those projects
     // See also https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
+    'unicorn/filename-case': 'off',
     'unicorn/no-null': 'off',
     'unicorn/no-useless-undefined': 'off',
     'unicorn/prefer-query-selector': 'off',

--- a/typescript.js
+++ b/typescript.js
@@ -50,9 +50,6 @@ const rules = {
   // The unicorn rule to disallow array.forEach() conflicts directly with the airbnb rule to disallow loops
   // In this case, we choose to follow the airbnb guidelines. See also https://github.com/airbnb/javascript/issues/1271
   'unicorn/no-array-for-each': 'off',
-
-  // This goes against the principle set by one of the most popular linting packages. See also https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
-  'unicorn/filename-case': 'off',
 }
 
 // Add plugins that should be used in both vanilla JS and TS linting


### PR DESCRIPTION
![Thank you for reviewing](https://media.giphy.com/media/KB8C86UMgLDThpt4WT/giphy.gif)

^ Add a GIF to cheer up the reviewers? Change the url to add your own.

## Reason for this change
Reverted filename-case rule since I merged it without a review and that's not the policy.

## Impact of this change on existing projects
Untire-nxt-backend lint tests will fail. but I'll update those.

Add this snippet to a specific projects eslint config to (temporarily) ignore the proposed change.

```js
// Snippet
```
