### PR TITLE
Add nextjs typescript base config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,7 @@ This library requires node 16+.
 }
 ```
 
-**For bare TypeScript projects**
-
-3. Setup your project config in `.eslintrc.js`:
+3. Setup your linting config in `.eslintrc.js`:
 
 ```js
 // This enables ESLint to use dependencies of this config
@@ -37,59 +35,25 @@ This library requires node 16+.
 require('eslint-config-toc/setup-plugins')
 
 module.exports = {
-  extends: ['toc/typescript'],
+  // Uncomment only ONE (the most applicable) config for your project and remove the others
+  // extends: ['toc/typescript'],
+  // extends: ['toc/react'],
+  // extends: ['toc/nexstjs'],
+  // extends: ['toc/react-native'],
 }
 ```
 
-4. Add `"extends": "eslint-config-toc/tsconfig-typescript.json"` to your `tsconfig.json`.
+4. Set up your TypeScript config in `tsconfig.json`. If your project was generated with a tsconfig file, make sure to remove all specific rules to prevent conflicts:
 
-**For React web projects**
-
-3. Setup your project config in `.eslintrc.js`:
-
-```js
-// This enables ESLint to use dependencies of this config
-// (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins')
-
-module.exports = {
-  extends: ['toc/react'],
+```json
+{
+  // Uncomment only ONE (the most applicable) config for your project and remove the others
+  // "extends": "eslint-config-toc/tsconfig-typescript.json",
+  // "extends": "eslint-config-toc/tsconfig-react.json",
+  // "extends": "eslint-config-toc/tsconfig-nextjs.json",
+  // "extends": "eslint-config-toc/tsconfig-react-native.json",
 }
 ```
-
-4. Add `"extends": "eslint-config-toc/tsconfig-react.json"` to your `tsconfig.json`.
-
-**For NextJS web projects**
-
-3. Setup your project config in `.eslintrc.js`:
-
-```js
-// This enables ESLint to use dependencies of this config
-// (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins')
-
-module.exports = {
-  extends: ['toc/nexstjs'],
-}
-```
-
-4. Add `"extends": "eslint-config-toc/tsconfig-react.json"` to your `tsconfig.json`.
-
-**For React Native projects**
-
-3. Setup your project config in `.eslintrc.js`:
-
-```js
-// This enables ESLint to use dependencies of this config
-// (see https://github.com/eslint/eslint/issues/3458)
-require('eslint-config-toc/setup-plugins')
-
-module.exports = {
-  extends: ['toc/react-native'],
-}
-```
-
-4. Add `"extends": "eslint-config-toc/tsconfig-react-native.json"` to your `tsconfig.json`.
 
 5. Happy linting! 🎉
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "repository": "https://github.com/tired-of-cancer/eslint-config-toc",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint .",
-    "prettier": "prettier --write ."
+    "lint": "eslint . --fix && prettier --write ."
   },
   "keywords": [
     "eslint",
@@ -23,6 +22,7 @@
     "tsconfig-typescript.json",
     "tsconfig-react.json",
     "tsconfig-react-native.json",
+    "tsconfig-nextjs.json",
     ".prettierrc.js"
   ],
   "devDependencies": {
@@ -35,6 +35,7 @@
     "@react-native-community/eslint-config": "^3.0.3",
     "@rushstack/eslint-patch": "^1.1.4",
     "@tsconfig/create-react-app": "^1.0.2",
+    "@tsconfig/next": "^1.0.2",
     "@tsconfig/react-native": "^2.0.2",
     "@tsconfig/recommended": "^1.0.1",
     "@typescript-eslint/eslint-plugin": "^5.30.6",

--- a/tsconfig-nextjs.json
+++ b/tsconfig-nextjs.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@tsconfig/next/tsconfig.json",
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,6 +350,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/create-react-app/-/create-react-app-1.0.2.tgz#e05e2d209b98e21665ed4097fe2d37f638447b0e"
   integrity sha512-Vg+pErSM6hTcSzxPqNwFg0dk+y0R1Obp8uLV1MDdfd7j98FyOFqtqkdxb9wqIx9vtDW5GCH7zg6DyoHJzMT12g==
 
+"@tsconfig/next@^1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/next/-/next-1.0.2.tgz#46a02b7b8cf5e716a5da3c2a319a5a41f7a2be3d"
+  integrity sha512-8/iOg2XM5hZqs6+2asWLv04vzZ8eue7xe/ZWvLZD1cTSpulkTZLFKP+WEDzHGEZYeWpR+JlStWBZZJ7SL4a6pA==
+
 "@tsconfig/react-native@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@tsconfig/react-native/-/react-native-2.0.2.tgz#ac9b8ceb1de91e2f23ab89f915490a1a4afd65a0"


### PR DESCRIPTION
![Thank you for reviewing](https://media.giphy.com/media/RIkgfue3mXysO7Gw5h/giphy.gif)

## Reason for this change

Next.js projects need a different base config for their TypeScript setup than vanilla React projects. This PR proposes to add an extendable configuration file for those projects. It also unifies the setup steps in the documentation to keep a better overview.

## Impact of this change on existing projects

Current projects using Next.js should update their tsconfig file as described in the updated README.