### PR TITLE
Proposal: Update react tsconfig target

### DIFF
--- a/tsconfig-react.json
+++ b/tsconfig-react.json
@@ -1,3 +1,6 @@
 {
-  "extends": "@tsconfig/create-react-app/tsconfig.json"
+  "extends": "@tsconfig/create-react-app/tsconfig.json",
+  "compilerOptions": {
+    "target": "es2015"
+  }
 }


### PR DESCRIPTION
![Target](https://media.giphy.com/media/QFypAZbq5lz3i/giphy.gif)

## Reason for this change

As discussed in https://github.com/tired-of-cancer/untire-nxt-backend/pull/99#discussion_r1007286620; the tsconfig target for our react projects needed to be overridden to allow the use of certain (now standard) coding practices:

> The reason for this change is this warning:
> `Type 'Set<string>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher`
> When doing something like this:
> ```
>  const array = [1, 2, 3, 4, 1]
>  const arrayWithoutDuplicates = [...new Set(array)]
> ```

I propose that if this is the way of working we want, we should change the default config and not override the value at every individual project level. This config library extends the defaults from https://github.com/tsconfig/bases, and after some research I found that they already updated the `create-react-app` config 20 days ago. However, this version has not been published and I'm not sure when they will do so. That is why I propose to make this extension, which overrides our react config with the same value that the library updated recently (es2015).

## Impact of this change on existing projects

Projects that did not override the target should have no impact, since the standard is backwards compatible. Projects that did override the target should revert to extending the eslint-config-toc default after upgrading to a version with this change.