### PR TITLE
Propose disable react native a11y link rule

### DIFF
--- a/react-native.js
+++ b/react-native.js
@@ -17,5 +17,8 @@ module.exports = {
       'asc',
       { ignoreClassNames: false, ignoreStyleProperties: false },
     ],
+
+    // We don't need a valid "href" prop on Link components since they are not HTML links
+    'jsx-a11y/anchor-is-valid': 'off',
   },
 }


### PR DESCRIPTION
![Link](https://media.giphy.com/media/144Q1gg0FkTEVG/giphy.gif)

## Reason for this change

When using a component called `<Link ... />` in React Native, the `jsx-a11y/anchor-is-valid` rule will complain if there is no valid `href` property set. The logic behind this is that screenreaders on the web will require this property on `<a />` tags to handle them correctly. However, since React Native works with Pressables instead of HTML tags this is no issue there.

## Impact of this change on existing projects

There should be little to no impact. If this rule was ignored in specific cases the eslint-ignore statement may have to be removed to make CI pass.