### PR TITLE
Fix eslint react plugin conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "typescript": "4.9.5"
   },
   "resolutions": {
-    "eslint-plugin-react-native": "4.0.0"
+    "eslint-plugin-react-native": "4.0.0",
+    "eslint-plugin-react": "7.32.2"
   }
 }


### PR DESCRIPTION
![Conflict](https://media.giphy.com/media/7FgDCnVUXgEJJiT68U/giphy-downsized.gif)

## Reason for this change

Some of the recent dependency updates have caused a dependency resolution conflict for projects depending on this library. This can be solved by adding a resolution.