### PR TITLE
Propose disable unicorn no array callback reference

### DIFF
--- a/typescript.js
+++ b/typescript.js
@@ -50,6 +50,10 @@ const rules = {
   // The unicorn rule to disallow array.forEach() conflicts directly with the airbnb rule to disallow loops
   // In this case, we choose to follow the airbnb guidelines. See also https://github.com/airbnb/javascript/issues/1271
   'unicorn/no-array-for-each': 'off',
+
+  // This rule disallows callback references like .filter(method) which can make it hard to properly use TypeScript.
+  // In this case we rather have callback references than the need to use type casting.
+  'unicorn/no-array-callback-reference': 'off',
 }
 
 // Add plugins that should be used in both vanilla JS and TS linting


### PR DESCRIPTION
![callback](https://media.giphy.com/media/lSCn98OFrSzrap76P0/giphy-downsized.gif)

## Reason for this change

Function typing on array callbacks may get lost when not using them as a direct reference. See for example this issue on filtering undefined values from an array:

``` ts
const [breadOptions, setBreadOptions] = useState<Bread[]>([])

const breadResult = api?.products?.smallBreads || [] // (Bread | undefined)[]
const filteredBread = breadResult.filter((bread) => !!bread) // (Bread | undefined)[]

useEffect(() => {
  setBreadOptions(filteredBread) // !! (Bread | undefined)[] is not assignable to Bread[]
}, [breadResult])
```

The values are filtered, but TypeScript does not pick up on it. This can be solved with a helper method like [suggested here](https://stackoverflow.com/questions/43118692/typescript-filter-out-nulls-from-an-array). However, when we follow this Unicorn rule the outcome will be the same:

``` ts
function notEmpty<TValue>(
  value: TValue | null | undefined
): value is TValue {
  return value !== null && value !== undefined
}

const [breadOptions, setBreadOptions] = useState<Bread[]>([])

const breadResult = api?.products?.smallBreads || [] // (Bread | undefined)[]
const filteredBread = breadResult.filter((bread) => notEmpty(bread)) // (Bread | undefined)[]

useEffect(() => {
  setBreadOptions(filteredBread) // !! (Bread | undefined)[] is not assignable to Bread[]
}, [breadResult])
```

The only way to make this work is to reference the helper function directly:

``` ts
function notEmpty<TValue>(
  value: TValue | null | undefined
): value is TValue {
  return value !== null && value !== undefined
}

const [breadOptions, setBreadOptions] = useState<Bread[]>([])

const breadResult = api?.products?.smallBreads || [] // (Bread | undefined)[]
const filteredBread = breadResult.filter(notEmpty) // Bread[]

useEffect(() => {
  setBreadOptions(filteredBread) // ✅
}, [breadResult])
```

But this is currently blocked by the `unicorn/no-array-callback-reference` rule. 

The alternative would be to typecast the array, now that we know it to be empty of `undefined`:

``` ts 
const [breadOptions, setBreadOptions] = useState<Bread[]>([])

const breadResult = api?.products?.smallBreads || [] // (Bread | undefined)[]
const filteredBread = breadResult.filter((bread) => !!bread) // (Bread | undefined)[]

useEffect(() => {
  setBreadOptions(filteredBread as Bread[]) // 😰
}, [breadResult])
```

But that just overrides all type safety and can result in actual code issues if the filter is removed or changed later.

**TLDR:** I believe we are better off disabling this Unicorn linting rule.

## Impact of this change on existing projects

There is no impact when disabling this rule. If existing projects ignored the rule locally those comments will be pruned automatically on the next linter run.