### PR TITLE
Fix symlink creating when installing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,8 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint . --fix && prettier --write .",
-    "test": "yarn --cwd tests/react-native test && yarn --cwd tests/react test && yarn --cwd tests/typescript test && yarn --cwd tests/nextjs test",
-    "symlink": "yarn --cwd tests/react-native symlink && yarn --cwd tests/react symlink && yarn --cwd tests/typescript symlink && yarn --cwd tests/nextjs symlink",
-    "postinstall": "yarn symlink"
+    "test": "yarn symlink && yarn --cwd tests/react-native test && yarn --cwd tests/react test && yarn --cwd tests/typescript test && yarn --cwd tests/nextjs test",
+    "symlink": "yarn --cwd tests/react-native symlink && yarn --cwd tests/react symlink && yarn --cwd tests/typescript symlink && yarn --cwd tests/nextjs symlink"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbDJlM2JkYzNmaGdjNHdhYjhzcnhveTFud3YwbWh6cWF6bHQ3ZzIweCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/MJ6SslGZEYKhG/giphy.gif)

## Task

In #95, tests were added and `yarn symlink` was added as the package.json `postinstall` script. This caused `yarn symlink` to be run when users of this package installed it as a dependency, causing it to fail in CI environments like `eas build`. 

![image](https://github.com/tired-of-cancer/eslint-config-toc/assets/6184593/ea3c82d0-61b8-4a90-a0df-8235f5dee50c)

This was never the intend and I thought `postinstall` was only run when running `yarn install` in this package directory itself. But that was not the case (never too old to learn). I've changed the scripts, so that the symlinks are only created when running `yarn test`, which should solve the problem.

## Test plan

- CI tests pass

