### PR TITLE
Propose disallow jsx element type

### DIFF
--- a/react.js
+++ b/react.js
@@ -31,6 +31,21 @@ module.exports = {
       },
     ],
 
+    // Disallow using deprecated global JSX Element type in favor of ReactNode
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          'JSX.Element': {
+            message:
+              'Prefer "ReactNode" from React over the deprecated global JSX Element.',
+            fixWith: 'ReactNode',
+          },
+        },
+        extendDefaults: true,
+      },
+    ],
+
     // Some unicorn rules are not compatible with React, so we disable them for those projects
     // See also https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
     'unicorn/filename-case': 'off',


### PR DESCRIPTION
![no](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTRsMnQ5NTA0eDU3ejN1cGF5NjFxMWJiZ25pamZ3MTFsNXQ3dW11bSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gnE4FFhtFoLKM/giphy.gif)

## Reason for this change

We often use `JSX.Element` and `ReactNode` interchangeable for the same purpose (specifying that a component can be passed along through the props of a component). The most common example is `{ children: JSX.Element }` versus `{ children: ReactNode }`.

Not only can this be confusing, but the global JSX namespace [has been deprecated](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/64464) as well. This PR proposes an additional React rule that will disallow the deprecated `JSX.Element` type in favour of the `ReactNode` type.

## Impact of this change on existing projects

Typescript linting checks will fail on all usage of `JSX.Element` and suggest to replace it with `ReactNode`.

Add this snippet to a specific projects eslint config to (temporarily) ignore the proposed change.

```js
'@typescript-eslint/ban-types': [
  'error',
  {
    types: {
      'JSX.Element': false,
    },
    extendDefaults: true,
  },
],
```
