### PR TITLE
Disable un-escaped-entities-rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,9 @@
     ".prettierrc.js"
   ],
   "devDependencies": {
-    "eslint": "8.49.0",
-    "@types/node": "18"
+    "@types/node": "18",
+    "@types/react": "^18.3.11",
+    "eslint": "8.49.0"
   },
   "peerDependencies": {
     "eslint": "8.49.0"

--- a/react.js
+++ b/react.js
@@ -46,6 +46,10 @@ module.exports = {
       },
     ],
 
+    // Disable react/no-unescaped-entities as it causing false positives on single quotes in strings
+    // and proposing them to use escaped quotes instead (which interferes with translation.io)
+    'react/no-unescaped-entities': 'off',
+
     // Some unicorn rules are not compatible with React, so we disable them for those projects
     // See also https://github.com/sindresorhus/eslint-plugin-unicorn/issues/896
     'unicorn/filename-case': 'off',

--- a/tests/react/main.ts
+++ b/tests/react/main.ts
@@ -1,4 +1,0 @@
-export function main() {
-  // eslint-disable-next-line no-console
-  console.log('Hello React!')
-}

--- a/tests/react/main.tsx
+++ b/tests/react/main.tsx
@@ -1,0 +1,9 @@
+export function main() {
+  // eslint-disable-next-line no-console
+  console.log('Hello React!')
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function NoUnespacedEntitiesComponent() {
+  return <>Hello 'React!'</>
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -433,6 +433,19 @@
   resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz#d3357479a0fdfdd5907fe67e17e0a85c906e1301"
   integrity sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==
 
+"@types/prop-types@*":
+  version "15.7.13"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.13.tgz#2af91918ee12d9d32914feb13f5326658461b451"
+  integrity sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==
+
+"@types/react@^18.3.11":
+  version "18.3.11"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.11.tgz#9d530601ff843ee0d7030d4227ea4360236bd537"
+  integrity sha512-r6QZ069rFTjrEYgFdOck1gK7FLVsgJE7tTz0pQBczlBNUhBNk0MQH4UbnFSwjpQLMkLzgqvBBa+qGpLje16eTQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
+
 "@types/semver@^7.3.12":
   version "7.3.13"
   resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.13.tgz#da4bfd73f49bd541d28920ab0e2bf0ee80f71c91"
@@ -855,6 +868,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+csstype@^3.0.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
+  integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
 damerau-levenshtein@^1.0.8:
   version "1.0.8"


### PR DESCRIPTION
![gif](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcWs4dTc4OTRrN2xnZmd1N3V4aWN4dm91N3M3d2g1a3I4bzUycm5maSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/eKrgVyZ7zLvJrgZNZn/giphy.gif)

## Task

Disables the `react/no-unescaped-entities` rule as it was interfering with the development process on the app. It caused single-quotes inside text components to be reported as errors, and it suggested to replace them by quote-codes. This is not what we want, as this does not play well with `translation.io`. This PR disabled them, allowing us to remove all the rule exemptions from the codebase.

## Test plan

- Added test-case
- Tests run in CI